### PR TITLE
Feature/refactor fog components

### DIFF
--- a/lib/jellyfish_fog.rb
+++ b/lib/jellyfish_fog.rb
@@ -11,11 +11,14 @@ require 'jellyfish_fog/storage'
 
 module Jellyfish
   module Fog
-    def self.aws_settings
-      {
-        aws_access_key_id: ENV.fetch('JELLYFISH_AWS_ACCESS_KEY_ID'),
-        aws_secret_access_key: ENV.fetch('JELLYFISH_AWS_SECRET_ACCESS_KEY')
-      }
+    module AWS
+      def self.settings
+        {
+          provider: 'aws',
+          aws_access_key_id: ENV.fetch('JELLYFISH_AWS_ACCESS_KEY_ID'),
+          aws_secret_access_key: ENV.fetch('JELLYFISH_AWS_SECRET_ACCESS_KEY')
+        }
+      end
     end
     module VMWare
       def self.settings
@@ -31,7 +34,7 @@ module Jellyfish
     module Azure
       def self.settings
         {
-          provider: 'Azure',
+          provider: 'azure',
           azure_sub_id: ENV.fetch('JELLYFISH_AZURE_SUB_ID'),
           azure_pem: ENV.fetch('JELLYFISH_AZURE_PEM_PATH'),
           azure_api_url: ENV.fetch('JELLYFISH_AZURE_API_URL')

--- a/lib/jellyfish_fog/databases.rb
+++ b/lib/jellyfish_fog/databases.rb
@@ -31,7 +31,7 @@ module Jellyfish
         end
 
         def connection
-          ::Fog::AWS::RDS.new(Jellyfish::Fog.aws_settings)
+          ::Fog::AWS::RDS.new(Jellyfish::Fog::AWS.settings.except(:provider))
         end
 
         def identifier

--- a/lib/jellyfish_fog/infrastructure.rb
+++ b/lib/jellyfish_fog/infrastructure.rb
@@ -48,7 +48,7 @@ module Jellyfish
         private
 
         def connection
-          ::Fog::Compute.new(Jellyfish::Fog.aws_settings.merge(provider: 'AWS'))
+          ::Fog::Compute.new(Jellyfish::Fog::AWS.settings)
         end
 
         def server_identifier

--- a/lib/jellyfish_fog/infrastructure.rb
+++ b/lib/jellyfish_fog/infrastructure.rb
@@ -9,12 +9,9 @@ module Jellyfish
             server = connection.vm_clone(details)
           end
 
-          minimized_payload = {}
-          minimized_payload[:id]   = server['new_vm']['id']
-          minimized_payload[:name] = server['new_vm']['name']
-          minimized_payload[:uuid] = server['new_vm']['uuid']
+          server['new_vm'] = server['new_vm'].except('parent')
           @order_item.provision_status = 'ok'
-          @order_item.payload_response = minimized_payload.to_json
+          @order_item.payload_response = server.to_json
         end
 
         private

--- a/lib/jellyfish_fog/storage.rb
+++ b/lib/jellyfish_fog/storage.rb
@@ -24,7 +24,7 @@ module Jellyfish
         private
 
         def connection
-          ::Fog::Storage.new(Jellyfish::Fog.aws_settings.merge(provider: 'AWS'))
+          ::Fog::Storage.new(Jellyfish::Fog::AWS.settings)
         end
 
         def storage_key

--- a/spec/lib/jellyfish_fog/vmware_infrastructure_spec.rb
+++ b/spec/lib/jellyfish_fog/vmware_infrastructure_spec.rb
@@ -23,7 +23,7 @@ module Jellyfish
           run_in_mock_mode
 
           allow(order_item).to receive_message_chain(:provision_status=).with('ok')
-          allow(order_item).to receive_message_chain(:payload_response=).with(vmware_server.response['new_vm'].to_json)
+          allow(order_item).to receive_message_chain(:payload_response=).with(vmware_server.response.to_json)
 
           new_vm_spec = Infrastructure.new(order_item)
 
@@ -32,7 +32,7 @@ module Jellyfish
           allow(new_vm_spec).to receive_message_chain('connection.vm_clone.get_datacenter') { true }
           allow(new_vm_spec).to receive_message_chain('connection.vm_clone') { vmware_server.response }
 
-          expect(new_vm_spec.provision).to eq('{"id":"50186187-12e0-5c4a-67bd-ce1b670a8f5d","name":"RHEL6_TEST_CLONE","uuid":"4218c19a-7c5e-238f-1cea-fb2ffc3349dd"}')
+          expect(new_vm_spec.provision).to eq(vmware_server.response.to_json)
         end
 
         def run_in_mock_mode


### PR DESCRIPTION
Changes:
- moves aws settings into csp specific module
- excludes vmware server response parent attribute to allow payload to be stored as json
